### PR TITLE
PRIVMSG event fix

### DIFF
--- a/lib/cinch/irc.rb
+++ b/lib/cinch/irc.rb
@@ -159,7 +159,7 @@ module Cinch
         end
 
         if msg.command == "PRIVMSG"
-          events << [:message]
+          events << [:message] << [:privmsg]
         else
           events << [:notice]
         end


### PR DESCRIPTION
Create :privmsg event when PRIVMSG command is received.
As per Bot#on documentation :privmsg event should be created as well as :message.
