### PR TITLE
Moved instance_eval in Cinch::Bot#initialize to before the on(:connect)

### DIFF
--- a/lib/cinch/bot.rb
+++ b/lib/cinch/bot.rb
@@ -500,14 +500,14 @@ module Cinch
 
       @user_manager = UserManager.new(self)
       @channel_manager = ChannelManager.new(self)
+      
+      instance_eval(&b) if block_given?
 
       on :connect do
         bot.config.channels.each do |channel|
           bot.join channel
         end
-      end
-
-      instance_eval(&b) if block_given?
+      end   
     end
 
     # The bot's nickname.


### PR DESCRIPTION
Fixes issue where logging to a file doesn't capture everything due to
debug line in Cinch::Bot#on.  Helpful for cleaning up output on tests, too.
