### PR TITLE
Now setting mode correctly when no param found.

### DIFF
--- a/lib/cinch/irc.rb
+++ b/lib/cinch/irc.rb
@@ -289,7 +289,7 @@ module Cinch
           else
             # channel options
             if direction == :add
-              msg.channel.modes_unsynced[mode] = param
+              msg.channel.modes_unsynced[mode] = param.nil? ? true : param
             else
               msg.channel.modes_unsynced.delete(mode)
             end


### PR DESCRIPTION
Previously, modes for +i would not get set in the Channel due to the param being nil.

oferrigni & zarniwoop
