### PR TITLE
Argument usage now matches name.

### DIFF
--- a/lib/cinch/channel.rb
+++ b/lib/cinch/channel.rb
@@ -183,7 +183,7 @@ module Cinch
     end
     alias_method :moderated?, :moderated
 
-    def moderated=(val)
+    def moderated=(bool)
       if bool
         mode "+m"
       else


### PR DESCRIPTION
Moderated= named the parameter bool and used a instance variable named val.  Fixed to match names.

oferrigni & zarniwoop
