### PR TITLE
Don't add \r\n to every line.

### DIFF
--- a/lib/cinch/message_queue.rb
+++ b/lib/cinch/message_queue.rb
@@ -65,7 +65,7 @@ module Cinch
         end
 
         begin
-          @socket.writeline Cinch::Utilities::Encoding.encode_outgoing(message, @bot.config.encoding) + "\r\n"
+          @socket.writeline Cinch::Utilities::Encoding.encode_outgoing(message, @bot.config.encoding)
           @log << Time.now
           @bot.loggers.outgoing(message)
 


### PR DESCRIPTION
Net::BufferedIO#writeline already adds \r\n to every line, so this was
unnecessary.
