### PR TITLE
Add action_reply convenience method

### DIFF
--- a/lib/cinch/message.rb
+++ b/lib/cinch/message.rb
@@ -176,6 +176,24 @@ module Cinch
       @target.safe_send(text)
     end
 
+    # Reply to a message with an action.
+    #
+    # @param [String] text the action message
+    # @return [void]
+    def action_reply(text)
+      text = text.to_s
+      @target.action(text)
+    end
+
+    # Like #action_reply, but using {Target#safe_action} instead
+    #
+    # @param (see #action_reply)
+    # @return (see #action_reply)
+    def safe_action_reply(text)
+      text = text.to_s
+      @target.safe_action(text)
+    end
+
     # Reply to a CTCP message
     #
     # @return [void]


### PR DESCRIPTION
Added action_reply and safe_action_reply.

Safe_action_reply probably won't get much use but.. eh, there's a safe_reply so why not?

I had considered giving action_reply a 'postfix' option like reply has 'prefix' so you could do m.action_reply "pokes", true.... for \* cinchbot pokes nickname.... but that seemed like taking it too far. It's easy to get the nick and put it where you want which might not be at the end of the message.

Thoughts?
