### PR TITLE
use a valid server name in WHOIS

### DIFF
--- a/lib/cinch/irc.rb
+++ b/lib/cinch/irc.rb
@@ -18,9 +18,13 @@ module Cinch
     # @return [Network] The detected network
     attr_reader :network
 
+    # @return [String] The specific server we are connected to
+    attr_reader :server
+
     def initialize(bot)
       @bot      = bot
       @isupport = ISupport.new
+      @server = nil
     end
 
     # @return [TCPSocket]
@@ -566,6 +570,7 @@ module Cinch
     def on_001(msg, events)
       # Ensure that we know our real, possibly truncated or otherwise
       # modified nick.
+      @server = msg.prefix
       @bot.set_nick msg.params.first
     end
 

--- a/lib/cinch/user.rb
+++ b/lib/cinch/user.rb
@@ -154,7 +154,7 @@ module Cinch
       if @bot.irc.network.whois_only_one_argument?
         @bot.irc.send "WHOIS #@name"
       else
-        @bot.irc.send "WHOIS #@name #@name"
+        @bot.irc.send "WHOIS #{@bot.irc.server} #@name"
       end
     end
     alias_method :refresh, :whois


### PR DESCRIPTION
Usually, it doesn't matter what you specify as the server in a WHOIS.
But in one case, freenode was sending us a "no such server" error that
didn't include the server name (then the nick) and thus break synced
attributes.

By specifying a real server, we'll always get a "no such nick" instead
of a "no such server".

Still need to check if this works on "weird" networks that are known to behave wrong.
