### PR TITLE
Corrected join_part.rb example

### DIFF
--- a/examples/basic/join_part.rb
+++ b/examples/basic/join_part.rb
@@ -7,12 +7,12 @@ bot = Cinch::Bot.new do
     c.channels = ["#cinch-bots"]
 
     # Who should be able to access these plugins
-    @admin = "injekt"
+    @@admin = "injekt"
   end
 
   helpers do
     def is_admin?(user)
-      true if user.nick == @admin
+      true if user.nick == @@admin
     end
   end
 


### PR DESCRIPTION
Newbie here, but while following the example code, I found that the instance variable (@admin) declared in the configure section wasn't available to the helper functions. Changing it to a class variable allowed the example code to succeed - though I'm sure that's not the "proper" way of doing it.

Anyway, thanks for the great framework! I'm having lots of fun playing with it.
