### PR TITLE
Fix a single character typo in one of the method comments

### DIFF
--- a/lib/cinch/storage/yaml.rb
+++ b/lib/cinch/storage/yaml.rb
@@ -24,7 +24,7 @@ module Cinch
         @yaml[key]
       end
 
-      # (see Strage#[]=)
+      # (see Storage#[]=)
       def []=(key, value)
         @yaml[key] = value
       end


### PR DESCRIPTION
Was just browsing through here and noticed the typo of Storage to Strage
