### PR TITLE
Return a list of threads from HandlerList#dispatch

### DIFF
--- a/lib/cinch/handler.rb
+++ b/lib/cinch/handler.rb
@@ -74,11 +74,11 @@ module Cinch
     # @param [Message] message Message that caused the invocation
     # @param [Array] captures Capture groups of the pattern that are
     #   being passed as arguments
-    # @return [void]
+    # @return [Thread]
     def call(message, captures, arguments)
       bargs = captures + arguments
 
-      @thread_group.add Thread.new {
+      thread = Thread.new {
         @bot.loggers.debug "[New thread] For #{self}: #{Thread.current} -- #{@thread_group.list.size} in total."
 
         begin
@@ -93,6 +93,9 @@ module Cinch
           @bot.loggers.debug "[Thread done] For #{self}: #{Thread.current} -- #{@thread_group.list.size - 1} remaining."
         end
       }
+
+      @thread_group.add thread
+      thread
     end
 
     # @return [String]

--- a/lib/cinch/handler_list.rb
+++ b/lib/cinch/handler_list.rb
@@ -51,8 +51,9 @@ module Cinch
     #   and attached to the event, or nil.
     # @param [Array] *arguments A list of additional arguments to pass
     #   to event handlers
-    # @return [void]
+    # @return [Array<Thread>]
     def dispatch(event, msg = nil, *arguments)
+      threads = Array.new
       if handlers = find(event, msg)
         already_run = Set.new
         handlers.each do |handler|
@@ -66,9 +67,10 @@ module Cinch
             captures = []
           end
 
-          handler.call(msg, captures, arguments)
+          threads << handler.call(msg, captures, arguments)
         end
       end
+      threads
     end
 
     # @yield [handler] Yields all registered handlers


### PR DESCRIPTION
I have a plugin which wants to block on the execution of an event (being used as a hook to trigger other plugins to act). This pull request changes the return values of:

Handler#call: now returns the Thread it added to @thread_group
HandlerList#dispatch: now returns an array of Threads the event started

These methods previously returned void.

This allows this proof-of-concept plugin to run as expected: https://gist.github.com/nickrw/5769705
