### PR TITLE
Allow hooks for specific matcher groups

### DIFF
--- a/lib/cinch/plugin.rb
+++ b/lib/cinch/plugin.rb
@@ -286,11 +286,7 @@ module Cinch
           hooks.select! { |hook| (events & hook.for).size > 0 }
         end
 
-        if group.nil?
-          return hooks.select { |hook| hook.group.nil? }
-        else
-          return hooks.select { |hook| hook.group.nil? || hook.group == group }
-        end
+        return hooks.select { |hook| hook.group.nil? || hook.group == group }
       end
 
       # @return [Boolean] True if processing should continue


### PR DESCRIPTION
Fixes #143.

Hooks without groups are always executed. Matchers execute the global hooks (the ones lacking groups) along with the hooks in their group.
