### PR TITLE
ignore +R option

### DIFF
--- a/lib/cinch/irc.rb
+++ b/lib/cinch/irc.rb
@@ -475,6 +475,8 @@ module Cinch
               process_ban_mode(msg, events, param, direction)
             when "q"
               process_owner_mode(msg, events, param, direction) if @network.owner_list_mode
+            when "R"
+              # Just ignore +R option
             else
               raise Exceptions::UnsupportedMode, mode
             end


### PR DESCRIPTION
This pullreq makes Cinch ignore `+R` mode.

When Cinch joins a channel with `+R` mode, it outputs error messages and continues to run.
`+R` stands for `REOP_LIST`, so Cinch doesn't have to do something about it (at least right now).
I think it should just be ignored.
