### PR TITLE
Italic uses wrong color code, which displays as reverse video in some clients

### DIFF
--- a/lib/cinch/formatting.rb
+++ b/lib/cinch/formatting.rb
@@ -66,7 +66,7 @@ module Cinch
       :underline  => 31.chr,
       :reversed   => 22.chr,
       :reverse    => 22.chr,
-      :italic     => 22.chr,
+      :italic     => 29.chr,
       :reset      => 15.chr,
     }
 


### PR DESCRIPTION
Some clients display reverse video as Italic, while others display it as reverse video. This leads to inconsistency in display, giving some users italic while others get reverse video, which can be hard on the eyes.

This changes the character code for italic to `\x1D`, or `29`, which shows up as italic across most clients
