### PR TITLE
Detect differences in nickname between our copy and a 311 WHOIS reply

### DIFF
--- a/lib/cinch/irc.rb
+++ b/lib/cinch/irc.rb
@@ -621,7 +621,13 @@ module Cinch
 
     def on_311(msg, events)
       # RPL_WHOISUSER
-      user = User(msg.params[1])
+      verbatim_nick = msg.params[1]
+      user = User(verbatim_nick)
+      if user.nick != verbatim_nick
+        # indicates that a nick has become out of sync with our cache due to
+        # a case-only change while offline or not in a channel with the bot
+        user.update_nick(verbatim_nick)
+      end
       update_whois(user, {
                      :user => msg.params[2],
                      :host => msg.params[3],


### PR DESCRIPTION
User#nick always returns a nick in the same case as the first time the bot saw that user online, because it is cached, case insensitive, in the UserList.

To reproduce, use something like the following:

```
match /echoname ([^ ]+)$/, :method => :echoname
def echoname(m, user)
  uobj = User(user)
  m.reply(uobj.nick)
end
```
- call !echoname someuser (bot replies someuser)
- have the user part the channel, change the case of their name only (someUser)
- call !echoname someUser (bot still replies someuser instead of someUser)

The attached patch detects differences between User#nick and the nickname returned by a 311 WHOIS reply message and calls User#update_nick if necessary.
