### PR TITLE
Changed Nokogiri::HTML to Nokogiri.parse to help properly handle UTF-8.

### DIFF
--- a/examples/basic/google.rb
+++ b/examples/basic/google.rb
@@ -15,7 +15,7 @@ bot = Cinch::Bot.new do
     # or "No results found" otherwise
     def google(query)
       url = "http://www.google.com/search?q=#{CGI.escape(query)}"
-      res = Nokogiri::HTML(open(url)).at("h3.r")
+      res = Nokogiri.parse(open(url.to_s).read).at("h3.r")
 
       title = res.text
       link = res.at('a')[:href]

--- a/examples/plugins/google.rb
+++ b/examples/plugins/google.rb
@@ -9,7 +9,7 @@ class Google
 
   def search(query)
     url = "http://www.google.com/search?q=#{CGI.escape(query)}"
-    res = Nokogiri::HTML(open(url)).at("h3.r")
+    res = Nokogiri.parse(open(url.to_s).read).at("h3.r")
 
     title = res.text
     link = res.at('a')[:href]


### PR DESCRIPTION
Certain Google results pages weren't properly encoded causing a byte sequence error with gsub `.rbenv/versions/2.1.1/lib/ruby/2.1.0/cgi/util.rb:60:in `gsub': invalid byte sequence in UTF-8 (ArgumentError)`
