### PR TITLE
Use ISO-8859-1 instead of CP1252 for sending messages.

### DIFF
--- a/lib/cinch/utilities/encoding.rb
+++ b/lib/cinch/utilities/encoding.rb
@@ -11,11 +11,6 @@ module Cinch
           # is performed. This allows you to see non-ASCII from mIRC
           # users (non-UTF-8) and other users sending you UTF-8.
           #
-          # CP1252 encoding is compatible with ISO-8859-1 encoding. The
-          # reason for choice of it instead of ISO-8859-1 is that some
-          # IRC clients may send CP1252 messages. Cinch will never send them,
-          # but it's possible that others will actually do.
-          #
           # (from http://xchat.org/encoding/#hybrid)
           string.force_encoding("UTF-8")
           if !string.valid_encoding?
@@ -32,26 +27,10 @@ module Cinch
       def self.encode_outgoing(string, encoding)
         string = string.dup
         if encoding == :irc
-          # If your text contains only characters that fit inside the ISO-8859-1
-          # code page (aka Latin1), the entire line will be sent that way. mIRC
-          # users should see it correctly. XChat users who are using UTF-8 will
-          # also see it correctly, because it will fail UTF-8 validation and will
-          # be assumed to be ISO-8859-1, even by older XChat versions.
-          #
-          # If the text doesn't fit inside the ISO-8859-1 code page, (for example if you
-          # type Eastern European characters, or Russian) it will be sent as UTF-8. Only
-          # UTF-8 capable clients will be able to see these characters correctly
-          #
-          # (from http://xchat.org/encoding/#hybrid)
-          begin
-            string.encode!("ISO-8859-1")
-          rescue ::Encoding::UndefinedConversionError
-          end
-        else
-          string.encode!(encoding, {:invalid => :replace, :undef => :replace}).force_encoding("ASCII-8BIT")
+          encoding = "UTF-8"
         end
 
-        return string
+        return string.encode!(encoding, {:invalid => :replace, :undef => :replace}).force_encoding("ASCII-8BIT")
       end
     end
   end


### PR DESCRIPTION
Apparently, some IRC clients don't support CP1252 messages, from which I confirmed HexChat and Quassel IRC, but it's likely there are more IRC clients that don't support CP1252 (by the way, [CP1252](https://en.wikipedia.org/wiki/Windows-1252) is not [ISO-8859-1](https://en.wikipedia.org/wiki/ISO/IEC_8859-1)).

Following the [robustness principle](https://en.wikipedia.org/wiki/Robustness_principle), the IRC encoding was updated to send messages using ISO-8859-1, but read them using CP1252. ISO-8859-1, unlike CP1252 is supported practically everywhere.

This will cause a slight incompatibility issue with the clients that don't support UTF-8, but support CP1252 (not just ISO-8859-1). In my opinion it's better to make those rare messages readable for modern IRC clients, rather than old versions of IRC clients such as mIRC 6.16 released 10 years ago.
