### PR TITLE
Always reset user whois state upon 318

### DIFF
--- a/lib/cinch/irc.rb
+++ b/lib/cinch/irc.rb
@@ -648,14 +648,13 @@ module Cinch
       # RPL_ENDOFWHOIS
       user = User(msg.params[1])
 
-      if @whois_updates[user]
-        if @whois_updates[user].empty? && !user.attr(:unknown?, true, true)
-          user.end_of_whois(nil)
-        else
-          user.end_of_whois(@whois_updates[user])
-        end
-        @whois_updates.delete user
+      @whois_updates[user] ||= {}
+      if @whois_updates[user].empty? && !user.attr(:unknown?, true, true)
+        user.end_of_whois(nil)
+      else
+        user.end_of_whois(@whois_updates[user])
       end
+      @whois_updates.delete user
     end
 
     def on_319(msg, events)


### PR DESCRIPTION
Based on this client to server interaction:

```
<< WHOIS test test
>> :server 263 test WHOIS :This command could not be completed because it has been used recently, and is rate-limited.
>> :server 318 test test :End of /WHOIS list.
```

the user is stuck with `@in_whois` raised and will never ever update whois.
