### PR TITLE
Avoid deprecation warning in Target

### DIFF
--- a/lib/cinch/target.rb
+++ b/lib/cinch/target.rb
@@ -18,7 +18,7 @@ module Cinch
     # @return [void]
     # @see #safe_notice
     def notice(text)
-      msg(text, true)
+      send(text, true)
     end
 
     # Sends a PRIVMSG to the target.


### PR DESCRIPTION
`Target#notice` still called the deprecated `Target#msg`.