### PR TITLE
Fix a bug in splitting messages

### DIFF
--- a/lib/cinch/target.rb
+++ b/lib/cinch/target.rb
@@ -36,23 +36,37 @@ module Cinch
       split_start = @bot.config.message_split_start || ""
       split_end   = @bot.config.message_split_end   || ""
       command = notice ? "NOTICE" : "PRIVMSG"
+      max_bytesize = 510 - ":#{@bot.mask} #{command} #{@name} :".bytesize
+      max_bytesize_without_end = max_bytesize - split_end.bytesize
 
-      text.split(/\r\n|\r|\n/).each do |line|
-        maxlength = 510 - (":" + " #{command} " + " :").size
-        maxlength = maxlength - @bot.mask.to_s.length - @name.to_s.length
-        maxlength_without_end = maxlength - split_end.bytesize
-
-        if line.bytesize > maxlength
+      text.lines.map(&:chomp).each do |line|
+        if line.bytesize > max_bytesize
           splitted = []
 
-          while line.bytesize > maxlength_without_end
-            pos = line.rindex(/\s/, maxlength_without_end)
-            r = pos || maxlength_without_end
-            splitted << line.slice!(0, r) + split_end.tr(" ", "\u00A0")
-            line = split_start.tr(" ", "\u00A0") + line.lstrip
-          end
+          rest = line
+          while rest.bytesize > max_bytesize_without_end
+            accumulated_bytesize = line.each_char.reduce([]) do |acc, ch|
+              acc << ((acc.last || 0) + ch.bytesize)
+            end
+            max_slice_bytesize, max_slice_length = accumulated_bytesize.
+              select { |bytesize| bytesize <= max_bytesize_without_end }.
+              each_with_index.
+              to_a.
+              last
+            last_space_index = rest.rindex(/\s/, max_slice_length)
+            r = if last_space_index
+                  accumulated_bytesize[last_space_index] - 1
+                else
+                  max_slice_bytesize
+                end
 
-          splitted << line
+            splitted << (rest.byteslice(0...r) +
+                         split_end.tr(" ", "\u00A0"))
+            rest = split_start.tr(" ", "\u00A0") +
+              rest.byteslice(r...rest.bytesize).lstrip
+          end
+          splitted << rest
+
           splitted[0, (@bot.config.max_messages || splitted.size)].each do |string|
             string.tr!("\u00A0", " ") # clean string from any non-breaking spaces
             @bot.irc.send("#{command} #@name :#{string}")

--- a/test/lib/cinch/target.rb
+++ b/test/lib/cinch/target.rb
@@ -1,0 +1,128 @@
+require 'helper'
+
+class TargetTest < TestCase
+  module MessageSplit
+    Mask = 'msg_split!~msg_split@an-irc-client.some-provider.net'
+    Command = 'NOTICE'
+    Channel = '#msg_split_test'
+    Prefix = ":#{Mask} #{Command} #{Channel} :" # 78 bytes
+    MaxBytesize = 510 - Prefix.bytesize
+  end
+
+  test 'A short text should not be split' do
+    target = Cinch::Target.new(nil, nil)
+    short_lorem_ipsum =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, ' \
+      'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+
+    actual_chunks = target.__send__(:split_message,
+                                    short_lorem_ipsum, MessageSplit::Prefix,
+                                    '... ', ' ...')
+    expected_chunks = [short_lorem_ipsum]
+
+    assert(expected_chunks.all? { |string|
+      string.length < MessageSplit::MaxBytesize
+    })
+    assert_equal(expected_chunks, actual_chunks)
+  end
+
+  test 'A long single-byte text should be split at the correct position' do
+    target = Cinch::Target.new(nil, nil)
+    lorem_ipsum =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, ' \
+      'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ' \
+      'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris ' \
+      'nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in ' \
+      'reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla ' \
+      'pariatur. Excepteur sint occaecat cupidatat non proident, sunt in ' \
+      'culpa qui officia deserunt mollit anim id est laborum.'
+
+    expected_chunks = [
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, ' \
+      'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ' \
+      'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris ' \
+      'nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in ' \
+      'reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla ' \
+      'pariatur. Excepteur sint occaecat cupidatat non proident, sunt in ' \
+      'culpa qui officia deserunt mollit ...',
+
+      '... anim id est laborum.'
+    ]
+    actual_chunks = target.__send__(:split_message,
+                                    lorem_ipsum, MessageSplit::Prefix,
+                                    '... ', ' ...')
+
+    assert(expected_chunks.all? { |string|
+      string.length < MessageSplit::MaxBytesize
+    })
+    assert_equal(expected_chunks, actual_chunks)
+  end
+
+  test 'A long multi-byte text should be split at the correct position' do
+    target = Cinch::Target.new(nil, nil)
+    japanese_text =
+      '私はその人を常に先生と呼んでいた。だからここでもただ先生と書く' \
+      'だけで本名は打ち明けない。これは世間を憚かる遠慮というよりも、' \
+      'その方が私にとって自然だからである。私はその人の記憶を呼び起す' \
+      'ごとに、すぐ「先生」といいたくなる。筆を執っても心持は同じ事で' \
+      'ある。よそよそしい頭文字などはとても使う気にならない。'
+
+    expected_chunks = [
+      '私はその人を常に先生と呼んでいた。だからここでもただ先生と書く' \
+      'だけで本名は打ち明けない。これは世間を憚かる遠慮というよりも、' \
+      'その方が私にとって自然だからである。私はその人の記憶を呼び起す' \
+      'ごとに、すぐ「先生」といいたくなる。筆を執っても心持は同じ事で' \
+      'ある。よそよそしい頭文字などはとても ...',
+
+      '... 使う気にならない。'
+    ]
+    actual_chunks = target.__send__(:split_message,
+                                    japanese_text, MessageSplit::Prefix,
+                                    '... ', ' ...')
+
+    assert(expected_chunks.all? { |string|
+      string.length < MessageSplit::MaxBytesize
+    })
+    assert_equal(expected_chunks, actual_chunks)
+  end
+
+  test 'A very long multi-byte text should be split at the correct position' do
+    target = Cinch::Target.new(nil, nil)
+    japanese_text =
+      'JAPANESE_TEXT:親譲りの無鉄砲で小供の時から損ばかりしている。' \
+      '小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした' \
+      '事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由' \
+      'でもない。新築の二階から首を出していたら、同級生の一人が冗談に、' \
+      'いくら威張っても、そこから飛び降りる事は出来まい。弱虫やーい。' \
+      'と囃したからである。小使に負ぶさって帰って来た時、おやじが' \
+      '大きな眼をして二階ぐらいから飛び降りて腰を抜かす奴があるかと' \
+      '云ったから、この次は抜かさずに飛んで見せますと答えた。親類の' \
+      'ものから西洋製のナイフを貰って奇麗な刃を日に翳して、友達に' \
+      '見せていたら、一人が光る事は光るが切れそうもないと云った。'
+
+    expected_chunks = [
+      'JAPANESE_TEXT:親譲りの無鉄砲で小供の時から損ばかりしている。' \
+      '小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした' \
+      '事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由' \
+      'でもない。新築の二階から首を出していたら、同級生の一人が冗談に、' \
+      'いくら威張っても、そこから飛び降りる ...',
+
+      '... 事は出来まい。弱虫やーい。' \
+      'と囃したからである。小使に負ぶさって帰って来た時、おやじが' \
+      '大きな眼をして二階ぐらいから飛び降りて腰を抜かす奴があるかと' \
+      '云ったから、この次は抜かさずに飛んで見せますと答えた。親類の' \
+      'ものから西洋製のナイフを貰って奇麗な刃を日に翳して、友達に' \
+      '見せていたら、一人が ...',
+
+      '... 光る事は光るが切れそうもないと云った。'
+    ]
+    actual_chunks = target.__send__(:split_message,
+                                    japanese_text, MessageSplit::Prefix,
+                                    '... ', ' ...')
+
+    assert(expected_chunks.all? { |string|
+      string.length < MessageSplit::MaxBytesize
+    })
+    assert_equal(expected_chunks, actual_chunks)
+  end
+end


### PR DESCRIPTION
I fixed a bug in splitting messages containing multibyte characters.

# Issue

For example, the following Japanese message got broken by split.

```
# UTF-8 (the bytesize of a Japanese character is 3)
# maxlength_without_end == 425
私はその人を常に先生と呼んでいた。だからここでもただ先生と書くだけで本名は打ち明けない。これは世間を憚かる遠慮というよりも、その方が私にとって自然だからである。私はその人の記憶を呼び起すごとに、すぐ「先生」といいたくなる。筆を執っても心持は同じ事である。よそよそしい頭文字などはとても使う気にならない。
----
# Using ngIRCd
23:28:41 (msg_split) 私はその人を常に先生と呼んでいた。だからここでもただ先生と書くだけで本名は打ち明けない。これは世間を憚かる遠慮というよりも、その方が私にとって自然だからである。私はその人の記憶を呼び起すごとに、すぐ「先生」といいたくなる。筆を執っても心持は同じ事である。よそよそしい頭文字などはとて�[CUT]
23:28:41 (msg_split) ...
```
Previously Cinch::Target#send split such messages at the wrong position that was calculated from the number of characters instead of the byte size.

* https://github.com/cinchrb/cinch/blob/ba8d9f1c5a728d4ad084211d6c92f0171f77ea3c/lib/cinch/target.rb#L49
* https://github.com/cinchrb/cinch/blob/ba8d9f1c5a728d4ad084211d6c92f0171f77ea3c/lib/cinch/target.rb#L51