### PR TITLE
Make quitting daemon friendly

### DIFF
--- a/lib/cinch/bot.rb
+++ b/lib/cinch/bot.rb
@@ -83,6 +83,9 @@ module Cinch
     # @return [Boolean] whether the bot is in the process of disconnecting
     attr_reader :quitting
 
+    # @return [String] quit message to send to server
+    attr_reader :quit_message
+
     # @return [UserList] All {User users} the bot knows about.
     # @see UserList
     # @since 1.1.0
@@ -224,9 +227,7 @@ module Cinch
     # @return [void]
     def quit(message = nil)
       @quitting = true
-      command   = message ? "QUIT :#{message}" : "QUIT"
-
-      @irc.send command
+      @quit_command = message ? "QUIT :#{message}" : "QUIT"
     end
 
     # Connects the bot to a server.

--- a/lib/cinch/irc.rb
+++ b/lib/cinch/irc.rb
@@ -193,6 +193,19 @@ module Cinch
       end
     end
 
+    # @api private
+    # @return [Thread] The quit thread.
+    # @since 2.0.0
+    def start_quit_thread
+      Thread.new do
+        # Check every 1 second if the bot needs to be shut down.
+        while !@bot.quitting
+          sleep 1
+        end
+        self.send @bot.quit_message
+      end
+    end
+
     # @since 2.0.0
     def send_sasl
       if @bot.config.sasl.username && @sasl_current_method = @sasl_remaining_methods.pop
@@ -217,10 +230,12 @@ module Cinch
         reading_thread = start_reading_thread
         sending_thread = start_sending_thread
         ping_thread    = start_ping_thread
+        quit_thread    = start_quit_thread
 
         reading_thread.join
         sending_thread.kill
         ping_thread.kill
+        quit_thread.kill
       end
     end
 


### PR DESCRIPTION
bot.quit may very likely be called from a daemon's trap context... cannot do complicated things there, so just setup the quitting flags and let the main event loop handle the actual quit.