### PR TITLE
Avoid deprecation warnings on Target#safe_notice

### DIFF
--- a/lib/cinch/target.rb
+++ b/lib/cinch/target.rb
@@ -103,7 +103,7 @@ module Cinch
     # @see #safe_notice
     # @see #notice
     def safe_notice(text)
-      safe_msg(text, true)
+      safe_send(text, true)
     end
 
     # Invoke an action (/me) in/to the target.


### PR DESCRIPTION
As #188, Target#safe_notice should call #safe_send instead of the deprecated #safe_msg.