### PR TITLE
Added capability to detect channel owners in InspIRCd

### DIFF
--- a/lib/cinch/network.rb
+++ b/lib/cinch/network.rb
@@ -39,7 +39,7 @@ module Cinch
     # @return [String, nil] The mode used for getting the list of
     #   channel owners, if any
     def owner_list_mode
-      return "q" if @ircd == :unreal
+      return "q" if @ircd == :unreal or @ircd == :inspircd
     end
 
     # @return [String, nil] The mode used for getting the list of


### PR DESCRIPTION
It is supported on that IRCd via m_chanprotect module.

**Source:** https://wiki.inspircd.org/Modules/2.0/chanprotect