### PR TITLE
Allow Bot#configure to pass arguments through to its block.

### DIFF
--- a/lib/cinch/bot.rb
+++ b/lib/cinch/bot.rb
@@ -212,10 +212,12 @@ module Cinch
     # This method is used to set a bot's options. It indeed does
     # nothing else but yielding {Bot#config}, but it makes for a nice DSL.
     #
+    # @params [Array<Object>] args arguments to pass to the config block
     # @yieldparam [Struct] config the bot's config
+    # @yieldparam [Array<Object>] args arguments passed from this method
     # @return [void]
-    def configure
-      yield @config
+    def configure(*args)
+      yield @config, *args
     end
 
     # Disconnects from the server.


### PR DESCRIPTION
This is handy if you want to enclose some data when calling #configure. For example, if your program's config object just happens to be named "@config", you can pass it as an argument to configure to bind it to a new name in the scope of the block.