### PR TITLE
Fix hooks disappearing mysteriously

### DIFF
--- a/lib/cinch/plugin.rb
+++ b/lib/cinch/plugin.rb
@@ -310,7 +310,7 @@ module Cinch
           if hooks.is_a?(Hash)
             hooks = hooks.map { |k, v| v }
           end
-          hooks.select! { |hook| (events & hook.for).size > 0 }
+          hooks = hooks.select { |hook| (events & hook.for).size > 0 }
         end
 
         return hooks.select { |hook| hook.group.nil? || hook.group == group }


### PR DESCRIPTION
In the code path through __hooks where type and events are both non-nil,
hooks is a value in the @hooks instance variable, and calling #select!
on it modifies the array inside @hooks as well.

This was causing hooks to mysteriously disappear when hooks had disjoint
event types.

Use #select instead.