### PR TITLE
Fix safe_action

### DIFF
--- a/lib/cinch/target.rb
+++ b/lib/cinch/target.rb
@@ -128,7 +128,7 @@ module Cinch
     # @return (see #action)
     # @see #action
     def safe_action(text)
-      action(Cinch::Helpers.Sanitize(text))
+      action(Cinch::Helpers.sanitize(text))
     end
 
     # Send a CTCP to the target.


### PR DESCRIPTION
Prior to this fix, calling `safe_action` would invoke the `Sanitize` method in `Cinch::Helpers`, which isn't accessible without first including `Cinch::Helpers`. Using `sanitize` in `Cinch::Helpers` fixes this issue.
