### PR TITLE
Used sysread and smaller buffer

### DIFF
--- a/lib/cinch/dcc/outgoing/send.rb
+++ b/lib/cinch/dcc/outgoing/send.rb
@@ -102,18 +102,10 @@ module Cinch
         private
         def send_data(fd)
           @io.advise(:sequential)
-
-          while chunk = @io.read(8096)
-            while true
-              rs, ws = IO.select([fd], [fd])
-              if !rs.empty?
-                rs.first.recv(8096)
-              end
-              if !ws.empty?
-                ws.first.write(chunk)
-                break
-              end
-            end
+          while chunk = @io.read(1024)
+            rs, ws = IO.select([fd], [fd])
+            rs.first.sysread(1024)  unless rs.empty?
+            ws.first.syswrite(chunk) unless ws.empty?
           end
         end
       end


### PR DESCRIPTION
If i use sysread / syswrite and open the file with "rb" in the plugin. I could transfer the data 10 out of 10 times.
I am not sure where the problem is. If i do tcpdump on both ends, it works with the old version also.
As i am not a ruby coder, i am unable to say if this is a "solution"