### PR TITLE
Document :join event

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -154,6 +154,10 @@ This event gets triggered when a user in a channel gets half-opped.
 One additional argument, the user being half-opped, gets passed to the
 handler.
 
+## `:join`
+
+This event gets triggered when a user joins a channel
+
 
 ## `:leaving`
 


### PR DESCRIPTION
This PR adds an event `:joining` so cinch API can receive an event when a user joins a channel.

It was easy to add to the pre-existing `on_join` private method in `irc.rb`

I named it `:joining` to relate to `:leaving` event. If you want, I can change the name at your request (eg `:join` `:joined`)

Here's an example plugin that can use the new event:
```
require 'cinch'

module Cinch
  module Plugins
    class Misc
      include Cinch::Plugin

      listen_to :joining

      def listen(m)
        return if m.user == @bot

        m.reply "Hello #{m.user} :)"
      end
    end
  end
end

```