### PR TITLE
Fix definition element location

### DIFF
--- a/examples/basic/urban_dict.rb
+++ b/examples/basic/urban_dict.rb
@@ -19,7 +19,7 @@ bot = Cinch::Bot.new do
     # can be done.. it works!
     def urban_dict(query)
       url = "http://www.urbandictionary.com/define.php?term=#{CGI.escape(query)}"
-      CGI.unescape_html Nokogiri::HTML(open(url)).at("div.definition").text.gsub(/\s+/, ' ') rescue nil
+      CGI.unescape_html Nokogiri::HTML(open(url)).css("div.meaning").first.text.gsub(/\s+/, ' ').strip rescue nil
     end
   end
 


### PR DESCRIPTION
`div.definition` has been replaced by `div.meaning` as element location in urban dictionary HTML