### PR TITLE
Add formatting code for italic text to unformat method

### DIFF
--- a/lib/cinch/formatting.rb
+++ b/lib/cinch/formatting.rb
@@ -119,7 +119,7 @@ module Cinch
     # @return [String] The filtered string
     # @since 2.2.0
     def self.unformat(string)
-      string.gsub(/[\x02\x0f\x16\x1f\x12]|\x03(\d{1,2}(,\d{1,2})?)?/, '')
+      string.gsub(/[\x02\x0f\x16\x1d\x1f\x12]|\x03(\d{1,2}(,\d{1,2})?)?/, '')
     end
   end
 end


### PR DESCRIPTION
The `Cinch::Formatting.unformat` method previously did not remove the current formatting code for italic text, which was introduced in commit fb393c9153642d42e9f61c6131d5e863c948e5ae.