### PR TITLE
formatting: Remove italics codes from string

### DIFF
--- a/lib/cinch/formatting.rb
+++ b/lib/cinch/formatting.rb
@@ -119,7 +119,7 @@ module Cinch
     # @return [String] The filtered string
     # @since 2.2.0
     def self.unformat(string)
-      string.gsub(/[\x02\x0f\x16\x1f\x12]|\x03(\d{1,2}(,\d{1,2})?)?/, '')
+      string.gsub(/[\x02\x0f\x16\x1f\x1d\x12]|\x03(\d{1,2}(,\d{1,2})?)?/, '')
     end
   end
 end


### PR DESCRIPTION
First of all, thanks for making Cinch! It's my favorite bot-building tool, by far.

This commit fixes a minor bug, namely properly removing italics inside `unformat`.
