### PR TITLE
Security fixes and tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'minitest-autotest'
+gem 'rake'

--- a/lib/cinch/helpers.rb
+++ b/lib/cinch/helpers.rb
@@ -218,7 +218,7 @@ module Cinch
     # @return [String] The filtered string
     # @since 2.2.0
     def self.sanitize(string)
-      string.gsub(/[\x00-\x08\x10-\x1f\x7f]/, '')
+      string.gsub(/[\x00-\x08\x0a-\x1f\x7f]/, '')
     end
 
     # (see Formatting.unformat)

--- a/lib/cinch/logger/formatted_logger.rb
+++ b/lib/cinch/logger/formatted_logger.rb
@@ -40,8 +40,7 @@ module Cinch
       end
 
       def format_general(message)
-        # :print: doesn't call all of :space: so use both.
-        message.gsub(/[^[:print:][:space:]]/) do |m|
+        message.gsub(/[^[:print:]]/) do |m|
           colorize(m.inspect[1..-2], :bg_white, :black)
         end
       end

--- a/lib/cinch/message_queue.rb
+++ b/lib/cinch/message_queue.rb
@@ -16,7 +16,7 @@ module Cinch
       @queued_queues     = Set.new
 
       @mutex = Mutex.new
-      
+
       @time_since_last_send = nil
 
       @log = []
@@ -81,7 +81,7 @@ module Cinch
 
     def process_one
       queue = @queues_to_process.pop
-      message = queue.pop.to_s.chomp
+      message = queue.pop.to_s.each_line.first.chomp
 
       if queue.empty?
         @mutex.synchronize do

--- a/lib/cinch/target.rb
+++ b/lib/cinch/target.rb
@@ -112,7 +112,8 @@ module Cinch
     # @return [void]
     # @see #safe_action
     def action(text)
-      @bot.irc.send("PRIVMSG #@name :\001ACTION #{text}\001")
+      line = text.to_s.each_line.first.chomp
+      @bot.irc.send("PRIVMSG #@name :\001ACTION #{line}\001")
     end
 
     # Like {#action}, but remove any non-printable characters from

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,7 +13,7 @@ end
 
 require 'minitest/autorun'
 
-class TestCase < MiniTest::Unit::TestCase
+class TestCase < MiniTest::Test
   def self.test(name, &block)
     define_method("test_" + name, &block) if block
   end

--- a/test/lib/cinch/helpers.rb
+++ b/test/lib/cinch/helpers.rb
@@ -1,0 +1,8 @@
+require "helper"
+
+class HelperTest < TestCase
+  test "Sanitize should remove newlines" do
+    assert_equal "ab", Cinch::Helpers.sanitize("a\r\nb")
+  end
+end
+

--- a/test/lib/cinch/plugin.rb
+++ b/test/lib/cinch/plugin.rb
@@ -22,11 +22,11 @@ class PluginTest < TestCase
     @plugin.match(/pattern/)
     matcher = @plugin.matchers.last
 
-    assert_equal(1, @plugin.matchers.size, "Shoult not forget existing matchers")
-    assert_equal Cinch::Plugin::ClassMethods::Matcher.new(/pattern/, true, true, :execute), matcher
+    assert_equal(1, @plugin.matchers.size, "Should not forget existing matchers")
+    assert_equal Cinch::Plugin::ClassMethods::Matcher.new(/pattern/, true, true, :execute, nil, nil, nil, nil, false), matcher
 
     matcher = @plugin.match(/pattern/, use_prefix: false, use_suffix: false, method: :some_method)
-    assert_equal Cinch::Plugin::ClassMethods::Matcher.new(/pattern/, false, false, :some_method), matcher
+    assert_equal Cinch::Plugin::ClassMethods::Matcher.new(/pattern/, false, false, :some_method, nil, nil, nil, nil, false), matcher
   end
 
   test "should be able to listen to events" do
@@ -108,13 +108,13 @@ class PluginTest < TestCase
     @plugin.set :prefix,      "some prefix"
     @plugin.set :suffix,      "some suffix"
     @plugin.set :plugin_name, "some plugin"
-    @plugin.set :reacting_on,    :event1
+    @plugin.set :react_on,    :event1
 
     assert_equal "some help message", @plugin.help
     assert_equal "some prefix",       @plugin.prefix
     assert_equal "some suffix",       @plugin.suffix
     assert_equal "some plugin",       @plugin.plugin_name
-    assert_equal :event1,             @plugin.reacting_on
+    assert_equal :event1,             @plugin.react_on
   end
 
   test "should support `set(key => value, key => value, ...)`" do
@@ -122,13 +122,13 @@ class PluginTest < TestCase
                 :prefix      => "some prefix",
                 :suffix      => "some suffix",
                 :plugin_name => "some plugin",
-                :reacting_on    => :event1)
+                :react_on    => :event1)
 
     assert_equal "some help message", @plugin.help
     assert_equal "some prefix",       @plugin.prefix
     assert_equal "some suffix",       @plugin.suffix
     assert_equal "some plugin",       @plugin.plugin_name
-    assert_equal :event1,             @plugin.reacting_on
+    assert_equal :event1,             @plugin.react_on
   end
 
   test "should support `self.key = value`" do
@@ -136,13 +136,13 @@ class PluginTest < TestCase
     @plugin.prefix      = "some prefix"
     @plugin.suffix      = "some suffix"
     @plugin.plugin_name = "some plugin"
-    @plugin.reacting_on    = :event1
+    @plugin.react_on    = :event1
 
     assert_equal "some help message", @plugin.help
     assert_equal "some prefix",       @plugin.prefix
     assert_equal "some suffix",       @plugin.suffix
     assert_equal "some plugin",       @plugin.plugin_name
-    assert_equal :event1,             @plugin.reacting_on
+    assert_equal :event1,             @plugin.react_on
   end
 
   test "should support querying attributes" do
@@ -150,13 +150,13 @@ class PluginTest < TestCase
     @plugin.help = "I am a help message"
     @plugin.prefix = "^"
     @plugin.suffix = "!"
-    @plugin.react_on(:event1)
+    @plugin.react_on = :event1
 
     assert_equal "foo", @plugin.plugin_name
     assert_equal "I am a help message", @plugin.help
     assert_equal "^", @plugin.prefix
     assert_equal "!", @plugin.suffix
-    assert_equal :event1, @plugin.reacting_on
+    assert_equal :event1, @plugin.react_on
   end
 
   test "should have a default name" do

--- a/test/lib/cinch/wire.rb
+++ b/test/lib/cinch/wire.rb
@@ -1,0 +1,42 @@
+require "helper"
+
+class WireTest < TestCase
+  def setup
+    @bot = Cinch::Bot.new do
+      self.loggers.clear
+      @irc = Cinch::IRC.new(self)
+      @irc.setup
+      @name = "cinch"
+      # stub these so that they work without a real server connection
+      def user
+        "test"
+      end
+      def host
+        "testhost"
+      end
+    end
+    # put a StringIO in place of a socket
+    @io = StringIO.new
+    @bot.irc.instance_variable_set(:@socket, @io)
+    @queue = Cinch::MessageQueue.new(@io, @bot)
+    @bot.irc.instance_variable_set(:@queue, @queue)
+    @to_process = @queue.instance_variable_get(:@queues_to_process)
+  end
+
+  # return all the data sent over the wire
+  def sent
+    while !@to_process.empty?
+      @queue.__send__(:process_one)
+    end
+    @io.rewind
+    @io.read
+  end
+
+  test "should be able to inspect sent IRC commands in tests" do
+    @bot.send("hello,")
+    @bot.send("world!")
+    assert_equal "PRIVMSG cinch :hello,\r\nPRIVMSG cinch :world!\r\n", sent
+  end
+
+end
+

--- a/test/lib/cinch/wire.rb
+++ b/test/lib/cinch/wire.rb
@@ -43,5 +43,10 @@ class WireTest < TestCase
     assert_equal "PRIVMSG cinch :\001ACTION evil\001\r\n", sent
   end
 
+  test "should not be able to send more than one IRC command at a time" do
+    @bot.irc.send("first\r\nsecond")
+    assert_equal "first\r\n", sent
+  end
+
 end
 

--- a/test/lib/cinch/wire.rb
+++ b/test/lib/cinch/wire.rb
@@ -38,5 +38,10 @@ class WireTest < TestCase
     assert_equal "PRIVMSG cinch :hello,\r\nPRIVMSG cinch :world!\r\n", sent
   end
 
+  test "should not be able to inject IRC commands using newlines in actions" do
+    @bot.action("evil\r\nKICK #testchan John :Injecting commands")
+    assert_equal "PRIVMSG cinch :\001ACTION evil\001\r\n", sent
+  end
+
 end
 


### PR DESCRIPTION
I noticed a security issue with sending messages that could contain data from external sources, namely that there might be newlines that would then enable injecting IRC commands to the bot's connection. When starting to fix that, I also noticed that the existing tests were not running correctly, so I made a handful of changes to fix them.

I added tests for my fixes, and the basic case of checking what gets sent over the wire took a bit of work to implement. This is why I split off `process_one` from `MessageQueue.process!`.

`Target#action` doesn't split long messages (which might be a useful feature), so its way of constructing a raw IRC command made it possible to inject a newline. I added a more generic fix in MessageQueue to prevent ever sending more than one line per call. I think that this change is necessary, even if it might break some weird bot or plugin implementation.

Finally, I noticed that `sanitize()` was supposed to remove newlines according to its documentation, but it didn't.