### PR TITLE
Added fully fledged OPER handling.

### DIFF
--- a/lib/cinch/bot.rb
+++ b/lib/cinch/bot.rb
@@ -109,6 +109,10 @@ module Cinch
     # @since 2.0.0
     attr_reader :handlers
 
+    # The bot's OPER state.
+    # @return [Boolean]
+    attr_accessor :is_oper
+
     # The bot's modes.
     #
     # @return [Array<String>]
@@ -235,6 +239,7 @@ module Cinch
     #   `@config.plugins.plugins`?
     # @return [void]
     def start(plugins = true)
+      @is_oper = false
       @reconnects = 0
       @plugins.register_plugins(@config.plugins.plugins) if plugins
 

--- a/lib/cinch/configuration/bot.rb
+++ b/lib/cinch/configuration/bot.rb
@@ -4,7 +4,7 @@ module Cinch
   class Configuration
     # @since 2.0.0
     class Bot < Configuration
-      KnownOptions = [:server, :port, :ssl, :password, :nick, :nicks,
+      KnownOptions = [:server, :port, :ssl, :password, :nick, :nicks, :oper,
                       :realname, :user, :messages_per_second, :server_queue_size,
                       :strictness, :message_split_start, :message_split_end,
                       :max_messages, :plugins, :channels, :encoding, :reconnect, :max_reconnect_delay,
@@ -22,6 +22,10 @@ module Cinch
           :realname => "cinch",
           :user => "cinch",
           :modes => [],
+          :oper => {
+            "user" => "",
+            "pass" => ""
+          },
           :messages_per_second => nil,
           :server_queue_size => nil,
           :strictness => :forgiving,

--- a/lib/cinch/configuration/bot.rb
+++ b/lib/cinch/configuration/bot.rb
@@ -22,10 +22,7 @@ module Cinch
           :realname => "cinch",
           :user => "cinch",
           :modes => [],
-          :oper => {
-            "user" => "",
-            "pass" => ""
-          },
+          :oper => nil,
           :messages_per_second => nil,
           :server_queue_size => nil,
           :strictness => :forgiving,

--- a/lib/cinch/irc.rb
+++ b/lib/cinch/irc.rb
@@ -819,6 +819,12 @@ module Cinch
       msg.channel.mark_as_synced(:bans)
     end
 
+    def on_381(msg, events)
+      @bot.is_oper = true
+      update_whois(@bot, {:oper? => true})
+      events << [:oper]
+    end
+
     def on_386(msg, events)
       # RPL_QLIST
       unless @in_lists.include?(:owners)
@@ -828,12 +834,6 @@ module Cinch
 
       owner = User(msg.params[2])
       msg.channel.owners_unsynced << owner
-    end
-
-    def on_381(msg, events)
-      @bot.is_oper = true
-      update_whois(@bot, {:oper? => true})
-      events << [:oper]
     end
 
     def on_387(msg, events)
@@ -881,6 +881,10 @@ module Cinch
       update_whois(user, {:secure? => true})
     end
 
+    def on_464(msg, events)
+      events << [:oper_fail]
+    end
+    
     # @since 2.0.0
     def on_730(msg, events)
       # RPL_MONONLINE

--- a/lib/cinch/irc.rb
+++ b/lib/cinch/irc.rb
@@ -610,7 +610,7 @@ module Cinch
       # Ensure that we know our real, possibly truncated or otherwise
       # modified nick.
       @bot.set_nick msg.params.first
-      if @bot.config.oper["user"] != "" && @bot.config.oper["pass"] != ""
+      if !@bot.config.oper.nil? && @bot.config.oper["user"] != "" && @bot.config.oper["pass"] != ""
         @bot.oper @bot.config.oper["pass"], @bot.config.oper["user"]
       end
     end

--- a/lib/cinch/irc.rb
+++ b/lib/cinch/irc.rb
@@ -95,7 +95,6 @@ module Cinch
         ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
       @bot.loggers.info "Using SSL with #{@bot.config.server}:#{@bot.config.port}"
-
       @socket      = OpenSSL::SSL::SSLSocket.new(socket, ssl_context)
       @socket.sync = true
       @socket.connect
@@ -611,6 +610,9 @@ module Cinch
       # Ensure that we know our real, possibly truncated or otherwise
       # modified nick.
       @bot.set_nick msg.params.first
+      if @bot.config.oper["user"] != "" && @bot.config.oper["pass"] != ""
+        @bot.oper @bot.config.oper["pass"], @bot.config.oper["user"]
+      end
     end
 
     # @since 2.0.0
@@ -826,6 +828,12 @@ module Cinch
 
       owner = User(msg.params[2])
       msg.channel.owners_unsynced << owner
+    end
+
+    def on_381(msg, events)
+      @bot.is_oper = true
+      update_whois(@bot, {:oper? => true})
+      events << [:oper]
     end
 
     def on_387(msg, events)


### PR DESCRIPTION
This adds sending an OPER request automatically if 
`@bot.config.oper["user"]`
`@bot.config.oper["pass"]`
are set in your config, in on_001.

This adds an :oper event, which can be listened for. This happens if the client recieves a 381, which signifies that the client is now an operator. 
`listen_to :oper, method: :test`

This adds an :oper_fail event, which can be listened for. This happens if the client recieves a 464, which is an invalid password event.
`listen_to :oper_fail, method: :test`

This adds a `@bot.is_oper` boolean.