### PR TITLE
Fix IRC message parsing expression

### DIFF
--- a/lib/cinch/message.rb
+++ b/lib/cinch/message.rb
@@ -97,7 +97,7 @@ module Cinch
     # @api private
     # @return [void]
     def parse
-      match = @raw.match(/(?:^@([^:]+))?(?::?(\S+) )?(\S+)(.*)/)
+      match = @raw.match(/\A(?:@([^ ]+) )?(?::(\S+) )?(\S+)(.*)/)
       tags, @prefix, @command, raw_params = match.captures
 
       if @bot.irc.network.ngametv?


### PR DESCRIPTION
This resolves an issue with Cinch not correctly parsing `AUTHENTICATE +` and potentially other types of messages.

See also b002f22251c7a933b27514831f373bbb02bc8af6.

Fixes #263.