### PR TITLE
[WIP] cinch: Configurable IP family for connections

### DIFF
--- a/docs/bot_options.md
+++ b/docs/bot_options.md
@@ -92,7 +92,7 @@ Type
 Default value
 : `300`
 
-Descriptipn
+Description
 : With every unsuccessful reconnection attempt, Cinch increases the
   delay between new attempts. This setting is the maximum number of
   seconds to wait between two attempts.
@@ -278,6 +278,17 @@ Description
 : The port the IRC server is listening on
 
 
+## inet
+Type
+: Symbol
+
+Default value
+: `nil`
+
+Description
+: The IP family to use for the IRC server connection. Set to `:PF_INET` for IPv4 only, or
+`:PF_INET5` for IPv6 only. By default, a random IP of either family is chosen.
+
 ## realname
 Type
 : String
@@ -451,4 +462,4 @@ Default value
 : `:debug`
 
 Description
-: Modify the log level of the default logger, for instance, the bot will log very little if you set this value to `:fatal`.  
+: Modify the log level of the default logger, for instance, the bot will log very little if you set this value to `:fatal`.

--- a/lib/cinch/configuration/bot.rb
+++ b/lib/cinch/configuration/bot.rb
@@ -4,7 +4,7 @@ module Cinch
   class Configuration
     # @since 2.0.0
     class Bot < Configuration
-      KnownOptions = [:server, :port, :ssl, :password, :nick, :nicks,
+      KnownOptions = [:server, :port, :inet, :ssl, :password, :nick, :nicks,
                       :realname, :user, :messages_per_second, :server_queue_size,
                       :strictness, :message_split_start, :message_split_end,
                       :max_messages, :plugins, :channels, :encoding, :reconnect, :max_reconnect_delay,
@@ -15,6 +15,7 @@ module Cinch
         {
           :server => "localhost",
           :port   => 6667,
+          :inet   => nil,
           :ssl    => Configuration::SSL.new,
           :password => nil,
           :nick   => "cinch",

--- a/lib/cinch/irc.rb
+++ b/lib/cinch/irc.rb
@@ -44,10 +44,11 @@ module Cinch
     # @return [Boolean] True if the connection could be established
     def connect
       tcp_socket = nil
+      addr = Addrinfo.getaddrinfo(@bot.config.server, @bot.config.port, @bot.config.inet, :STREAM).sample
 
       begin
         Timeout::timeout(@bot.config.timeouts.connect) do
-          tcp_socket = TCPSocket.new(@bot.config.server, @bot.config.port, @bot.config.local_host)
+          tcp_socket = TCPSocket.new(addr.ip_address, addr.ip_port, @bot.config.local_host)
         end
       rescue Timeout::Error
         @bot.loggers.warn("Timed out while connecting")


### PR DESCRIPTION
Allows users to avoid IPv4 or IPv6 connections to their intended IRC server.

In progress, untested. I'll confirm that this works tomorrow.